### PR TITLE
Use latest Debian release on Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 #
 # docker build -t crops/chameleonsocks -f Dockerfile .
 
-FROM debian:wheezy
+FROM debian
 MAINTAINER Todor Minchev <todor.minchev@linux.intel.com>
 ENV CHAMELEONSOCKS_VERSION 1.2
 


### PR DESCRIPTION
Using debian:wheezy caused an issue in Arch Linux where the container would not start. This was probably caused by an error with the binaries being linked against an older version of the kernel. In the end I fixed it by using the latest Debian version for the image.